### PR TITLE
Remove `/result`

### DIFF
--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/vx770r7vn3ryvfv2kb8jpjhz05lvzpgw-pipes-sqlite-simple-lib-pipes-sqlite-simple-0.2


### PR DESCRIPTION
Having the `/result` symlink folder here gives errors when trying to import the package via stack's `extra-deps`